### PR TITLE
Unifying optional and default values registration

### DIFF
--- a/examples/demo.h
+++ b/examples/demo.h
@@ -2,6 +2,8 @@
 #include <figcone/config.h>
 #include <figcone/shortmacros.h> //enables macros without FIGCONE_ prefix
 #include <string>
+#include <vector>
+#include <map>
 
 struct ThumbnailCfg : public figcone::Config<>
 {
@@ -16,12 +18,13 @@ struct HostCfg : public figcone::Config<>{
 struct SharedAlbumCfg : public figcone::Config<>{
     PARAM(dir, std::filesystem::path);
     PARAM(name, std::string);
-    NODELIST(hosts, HostCfg)();
+    NODELIST(hosts, std::vector<HostCfg>)();
 };
 struct PhotoViewerCfg : public figcone::Config<>{
     PARAM(rootDir, std::filesystem::path);
-    PARAMLIST(supportedFiles, std::string);
+    PARAMLIST(supportedFiles, std::vector<std::string>);
     NODE(thumbnails, ThumbnailCfg);
-    COPY_NODELIST(sharedAlbums, SharedAlbumCfg)();
-    DICT(envVars)();
+    COPY_NODELIST(sharedAlbums, std::vector<SharedAlbumCfg>)();
+    using StringMap = std::map<std::string, std::string>;
+    DICT(envVars, StringMap)();
 };

--- a/examples/ex01.cpp
+++ b/examples/ex01.cpp
@@ -1,6 +1,7 @@
 #include <figcone/config.h>
 #include <filesystem>
 #include <iostream>
+#include <vector>
 
 struct ThumbnailCfg : public figcone::Config<>
 {
@@ -10,7 +11,7 @@ struct ThumbnailCfg : public figcone::Config<>
 struct PhotoViewerCfg : public figcone::Config<>{
     //config fields can also be created with macros:
     FIGCONE_PARAM(rootDir, std::filesystem::path);
-    FIGCONE_PARAMLIST(supportedFiles, std::string);
+    FIGCONE_PARAMLIST(supportedFiles, std::vector<std::string>);
     FIGCONE_NODE(thumbnailSettings, ThumbnailCfg);
 };
 

--- a/examples/ex02.cpp
+++ b/examples/ex02.cpp
@@ -1,6 +1,7 @@
 #include <figcone/config.h>
 #include <filesystem>
 #include <iostream>
+#include <vector>
 
 struct ThumbnailCfg : public figcone::Config<figcone::NameFormat::SnakeCase>
 {   
@@ -10,7 +11,7 @@ struct ThumbnailCfg : public figcone::Config<figcone::NameFormat::SnakeCase>
 struct PhotoViewerCfg : public figcone::Config<figcone::NameFormat::SnakeCase>{
     //config fields can also be created with macros:
     FIGCONE_PARAM(rootDir, std::filesystem::path);
-    FIGCONE_PARAMLIST(supportedFiles, std::string);
+    FIGCONE_PARAMLIST(supportedFiles, std::vector<std::string>);
     FIGCONE_NODE(thumbnailSettings, ThumbnailCfg);
 };
 

--- a/examples/ex03.cpp
+++ b/examples/ex03.cpp
@@ -2,6 +2,8 @@
 #include <figcone/shortmacros.h> //enables macros without FIGCONE_ prefix
 #include <filesystem>
 #include <iostream>
+#include <vector>
+#include <map>
 
 struct Host{
     std::string ip;
@@ -26,13 +28,14 @@ struct StringConverter<Host>{
 struct SharedAlbumCfg : public figcone::Config<>{
     PARAM(dir, std::filesystem::path);
     PARAM(name, std::string);
-    PARAMLIST(hosts, Host)();
+    PARAMLIST(hosts, std::vector<Host>)();
 };
 struct PhotoViewerCfg : public figcone::Config<>{
     PARAM(rootDir, std::filesystem::path);
-    PARAMLIST(supportedFiles, std::string);
-    COPY_NODELIST(sharedAlbums, SharedAlbumCfg)();
-    DICT(envVars)();
+    PARAMLIST(supportedFiles, std::vector<std::string>);
+    COPY_NODELIST(sharedAlbums, std::vector<SharedAlbumCfg>)();
+    using StringMap = std::map<std::string, std::string>;
+    DICT(envVars, StringMap)();
 };
 
 int main()

--- a/examples/ex04.cpp
+++ b/examples/ex04.cpp
@@ -3,6 +3,8 @@
 #include <figcone/shortmacros.h>
 #include <filesystem>
 #include <iostream>
+#include <vector>
+#include<map>
 
 struct NotEmpty{
     template<typename TList>
@@ -18,8 +20,9 @@ struct PhotoViewerCfg : public figcone::Config<>{
         if (!std::filesystem::exists(path))
             throw figcone::ValidationError{"a path must exist"};
     });
-    PARAMLIST(supportedFiles, std::string).ensure<NotEmpty>();
-    DICT(envVars)();
+    PARAMLIST(supportedFiles, std::vector<std::string>).ensure<NotEmpty>();
+    using StringMap = std::map<std::string, std::string>;
+    DICT(envVars, StringMap)();
 };
 
 int main()

--- a/include/figcone/config.h
+++ b/include/figcone/config.h
@@ -244,11 +244,16 @@ private:
         return detail::NodeCreator<T>{*this, memberName, cfg->*member};
     }
 
-    template <auto member, typename TCfg>
-    auto dict(std::map<std::string, std::string> TCfg::*, const std::string& memberName)
+    template <auto member, typename TMap, typename TCfg>
+    auto dict(TMap TCfg::*, const std::string& memberName)
     {
+         static_assert(detail::is_associative_container_v<detail::maybe_opt_t<TMap>>,
+              "Dictionary field must be an associative container or an associative container placed in std::optional");
+        static_assert(std::is_same_v<typename detail::maybe_opt_t<TMap>::key_type, std::string>,
+                     "Dictionary associative container's key type must be std::string");
+
         auto cfg = static_cast<TCfg*>(this);
-        return detail::DictCreator{*this, memberName, cfg->*member};
+        return detail::DictCreator<TMap>{*this, memberName, cfg->*member};
     }
 
     template <auto member, typename TCfgList, typename TCfg>

--- a/include/figcone/config.h
+++ b/include/figcone/config.h
@@ -17,6 +17,7 @@
 #include "detail/figcone_ini_import.h"
 #include "detail/figcone_xml_import.h"
 #include "detail/nameof_import.h"
+#include "detail/utils.h"
 #include <figcone_tree/iparser.h>
 #include <figcone_tree/tree.h>
 #include <vector>
@@ -276,8 +277,11 @@ private:
     }
 
     template <auto member, typename T, typename TCfg>
-    auto paramList(std::vector<T> TCfg::*, const std::string& memberName)
+    auto paramList(T TCfg::*, const std::string& memberName)
     {
+        static_assert(detail::is_sequence_container_v<detail::maybe_opt_t<T>>,
+                      "Param list field must be a sequence container or a sequence container placed in std::optional");
+
         auto cfg = static_cast<TCfg*>(this);
         return detail::ParamListCreator<T>{*this, memberName, cfg->*member};
     }

--- a/include/figcone/config.h
+++ b/include/figcone/config.h
@@ -251,22 +251,26 @@ private:
         return detail::DictCreator{*this, memberName, cfg->*member};
     }
 
-    template <auto member, typename T, typename TCfg>
-    auto nodeList(std::vector<T> TCfg::*, const std::string& memberName)
+    template <auto member, typename TCfgList, typename TCfg>
+    auto nodeList(TCfgList TCfg::*, const std::string& memberName)
     {
-        static_assert(TCfg::format() == T::format(),
+        static_assert(detail::is_sequence_container_v<detail::maybe_opt_t<TCfgList>>,
+              "Node list field must be a sequence container or a sequence container placed in std::optional");
+        static_assert(TCfg::format() == detail::maybe_opt_t<TCfgList>::value_type::format(),
               "Node's config type must have the same name format as its parent.");
         auto cfg = static_cast<TCfg*>(this);
-        return detail::NodeListCreator<T>{*this, memberName, cfg->*member};
+        return detail::NodeListCreator<TCfgList>{*this, memberName, cfg->*member};
     }
 
-    template <auto member, typename T, typename TCfg>
-    auto copyNodeList(std::vector<T> TCfg::*, const std::string& memberName)
+    template <auto member, typename TCfgList, typename TCfg>
+    auto copyNodeList(TCfgList TCfg::*, const std::string& memberName)
     {
-        static_assert(TCfg::format() == T::format(),
+        static_assert(detail::is_sequence_container_v<detail::maybe_opt_t<TCfgList>>,
+              "Node list field must be a sequence container or a sequence container placed in std::optional");
+        static_assert(TCfg::format() == detail::maybe_opt_t<TCfgList>::value_type::format(),
               "Node's config type must have the same name format as its parent.");
         auto cfg = static_cast<TCfg*>(this);
-        return detail::NodeListCreator<T>{*this, memberName, cfg->*member, detail::NodeListType::Copy};
+        return detail::NodeListCreator<TCfgList>{*this, memberName, cfg->*member, detail::NodeListType::Copy};
     }
 
     template <auto member, typename T, typename TCfg>

--- a/include/figcone/detail/configmacros.h
+++ b/include/figcone/detail/configmacros.h
@@ -10,7 +10,7 @@
 
 #define FIGCONE_PARAM(name, type) type name = figcone::detail::makeParamCreator<type>(*this, #name, [this]()->type&{return name;})
 #define FIGCONE_NODE(name, type) type name = figcone::detail::makeNodeCreator<type>(*this, #name, [this]()->type&{return name;})
-#define FIGCONE_COPY_NODELIST(name, type) std::vector<type> name = figcone::detail::makeNodeListCreator<type>(*this, #name, [this]()->std::vector<type>&{return name;}, figcone::detail::NodeListType::Copy)
-#define FIGCONE_NODELIST(name, type) std::vector<type> name = figcone::detail::makeNodeListCreator<type>(*this, #name, [this]()->std::vector<type>&{return name;})
+#define FIGCONE_COPY_NODELIST(name, type) type name = figcone::detail::makeNodeListCreator<type>(*this, #name, [this]()->type&{return name;}, figcone::detail::NodeListType::Copy)
+#define FIGCONE_NODELIST(name, type) type name = figcone::detail::makeNodeListCreator<type>(*this, #name, [this]()->type&{return name;})
 #define FIGCONE_PARAMLIST(name, type) type name = figcone::detail::makeParamListCreator<type>(*this, #name, [this]()->type&{return name;})
 #define FIGCONE_DICT(name) std::map<std::string, std::string> name = figcone::detail::makeDictCreator(*this, #name, [this]()->std::map<std::string, std::string>&{return name;})

--- a/include/figcone/detail/configmacros.h
+++ b/include/figcone/detail/configmacros.h
@@ -12,5 +12,5 @@
 #define FIGCONE_NODE(name, type) type name = figcone::detail::makeNodeCreator<type>(*this, #name, [this]()->type&{return name;})
 #define FIGCONE_COPY_NODELIST(name, type) std::vector<type> name = figcone::detail::makeNodeListCreator<type>(*this, #name, [this]()->std::vector<type>&{return name;}, figcone::detail::NodeListType::Copy)
 #define FIGCONE_NODELIST(name, type) std::vector<type> name = figcone::detail::makeNodeListCreator<type>(*this, #name, [this]()->std::vector<type>&{return name;})
-#define FIGCONE_PARAMLIST(name, type) std::vector<type> name = figcone::detail::makeParamListCreator<type>(*this, #name, [this]()->std::vector<type>&{return name;})
+#define FIGCONE_PARAMLIST(name, type) type name = figcone::detail::makeParamListCreator<type>(*this, #name, [this]()->type&{return name;})
 #define FIGCONE_DICT(name) std::map<std::string, std::string> name = figcone::detail::makeDictCreator(*this, #name, [this]()->std::map<std::string, std::string>&{return name;})

--- a/include/figcone/detail/configmacros.h
+++ b/include/figcone/detail/configmacros.h
@@ -4,13 +4,10 @@
 #include "paramcreator.h"
 #include "paramlistcreator.h"
 #include "dictcreator.h"
-#include <vector>
-#include <string>
-#include <map>
 
 #define FIGCONE_PARAM(name, type) type name = figcone::detail::makeParamCreator<type>(*this, #name, [this]()->type&{return name;})
 #define FIGCONE_NODE(name, type) type name = figcone::detail::makeNodeCreator<type>(*this, #name, [this]()->type&{return name;})
-#define FIGCONE_COPY_NODELIST(name, type) type name = figcone::detail::makeNodeListCreator<type>(*this, #name, [this]()->type&{return name;}, figcone::detail::NodeListType::Copy)
-#define FIGCONE_NODELIST(name, type) type name = figcone::detail::makeNodeListCreator<type>(*this, #name, [this]()->type&{return name;})
-#define FIGCONE_PARAMLIST(name, type) type name = figcone::detail::makeParamListCreator<type>(*this, #name, [this]()->type&{return name;})
-#define FIGCONE_DICT(name) std::map<std::string, std::string> name = figcone::detail::makeDictCreator(*this, #name, [this]()->std::map<std::string, std::string>&{return name;})
+#define FIGCONE_COPY_NODELIST(name, listType) listType name = figcone::detail::makeNodeListCreator<listType>(*this, #name, [this]()->listType&{return name;}, figcone::detail::NodeListType::Copy)
+#define FIGCONE_NODELIST(name, listType) listType name = figcone::detail::makeNodeListCreator<listType>(*this, #name, [this]()->listType&{return name;})
+#define FIGCONE_PARAMLIST(name, listType) listType name = figcone::detail::makeParamListCreator<listType>(*this, #name, [this]()->listType&{return name;})
+#define FIGCONE_DICT(name, mapType) mapType name = figcone::detail::makeDictCreator<mapType>(*this, #name, [this]()->mapType&{return name;})

--- a/include/figcone/detail/dict.h
+++ b/include/figcone/detail/dict.h
@@ -1,17 +1,26 @@
 #pragma once
 #include "inode.h"
 #include "param.h"
+#include "utils.h"
 #include <figcone_tree/tree.h>
 #include <map>
+#include <string>
+#include <type_traits>
 
 namespace figcone::detail {
 
+template<typename TMap>
 class Dict : public INode{
 public:
-    explicit Dict(std::string name, std::map<std::string, std::string>& dictMap)
+    explicit Dict(std::string name, TMap& dictMap)
         : name_{std::move(name)}
         , dictMap_{dictMap}
-    {}
+    {
+        static_assert(is_associative_container_v<maybe_opt_t<TMap>>,
+                      "Dictionary field must be an associative container or an associative container placed in std::optional");
+        static_assert(std::is_same_v<typename maybe_opt_t<TMap>::key_type, std::string>,
+                     "Dictionary associative container's key type must be std::string");
+    }
 
     void markValueIsSet()
     {
@@ -25,12 +34,26 @@ private:
         position_ = node.position();
         if (!node.isItem())
            throw ConfigError{"Dictionary '" + name_ + "': config node can't be a list.", node.position()};
-        for (const auto& [paramName, paramValue] : node.asItem().params())
-           dictMap_[paramName] = paramValue.value();
+        if constexpr(is_optional<TMap>::value)
+           dictMap_.emplace();
+        maybeOptValue(dictMap_).clear();
+
+        for (const auto& [paramName, paramValueStr] : node.asItem().params())
+        {
+            auto paramValue = convertFromString<typename maybe_opt_t<TMap>::mapped_type>(paramValueStr.value());
+            if (!paramValue)
+                throw ConfigError{
+                        "Couldn't set dict element'" + name_ + "' value from '" + paramValueStr.value() + "'",
+                        position_};
+
+            maybeOptValue(dictMap_).emplace(paramName, *paramValue);
+        }
     }
 
     bool hasValue() const override
     {
+        if constexpr (is_optional<TMap>::value)
+            return true;
         return hasValue_;
     }
 
@@ -46,7 +69,7 @@ private:
 
 private:
     std::string name_;
-    std::map<std::string, std::string>& dictMap_;
+    TMap& dictMap_;
     bool hasValue_ = false;
     StreamPosition position_;
 };

--- a/include/figcone/detail/node.h
+++ b/include/figcone/detail/node.h
@@ -20,6 +20,11 @@ public:
     {
     }
 
+    void markValueIsSet()
+    {
+        hasValue_ = true;
+    }
+
 private:
     void load(const TreeNode& node) override
     {

--- a/include/figcone/detail/nodecreator.h
+++ b/include/figcone/detail/nodecreator.h
@@ -30,6 +30,12 @@ public:
         node_ = std::make_unique<Node<TCfg>>(nodeName_, nodeCfg_);
     }
 
+    NodeCreator<TCfg>& operator()()
+    {
+        node_->markValueIsSet();
+        return *this;
+    }
+
     operator TCfg()
     {
         cfg_.addNode(nodeName_, std::move(node_));

--- a/include/figcone/detail/nodecreator.h
+++ b/include/figcone/detail/nodecreator.h
@@ -19,14 +19,8 @@ public:
         , nodeName_{(Expects(!nodeName.empty()), std::move(nodeName))}
         , nodeCfg_{nodeCfg}
     {
-        if constexpr (detail::is_optional<TCfg>::value) {
-            static_assert(std::is_base_of_v<IConfig, typename TCfg::value_type>,
-                          "TConfig must be a subclass of figcone::IConfig.");
-            }
-        else {
-            static_assert(std::is_base_of_v<IConfig, TCfg>, "TConfig must be a subclass of figcone::IConfig.");
-
-        }
+        static_assert(std::is_base_of_v<IConfig, maybe_opt_t<TCfg>>,
+                      "TConfig must be a subclass of figcone::IConfig.");
         node_ = std::make_unique<Node<TCfg>>(nodeName_, nodeCfg_);
     }
 
@@ -67,11 +61,7 @@ NodeCreator<TCfg> makeNodeCreator(TParentCfg& parentCfg,
                                   std::string nodeName,
                                   const std::function<TCfg&()>& configGetter)
 {
-    if constexpr (detail::is_optional<TCfg>::value)
-        static_assert(TCfg::value_type::format() == TParentCfg::format(),
-                  "Node's config type must have the same name format as its parent.");
-    else
-        static_assert(TCfg::format() == TParentCfg::format(),
+    static_assert(maybe_opt_t<TCfg>::format() == TParentCfg::format(),
                   "Node's config type must have the same name format as its parent.");
     return {parentCfg, std::move(nodeName), configGetter()};
 }

--- a/include/figcone/detail/nodelist.h
+++ b/include/figcone/detail/nodelist.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "inode.h"
 #include "loadingerror.h"
+#include "utils.h"
 #include <figcone_tree/tree.h>
 #include <figcone/errors.h>
 #include <vector>
@@ -13,14 +14,17 @@ enum class NodeListType{
     Copy
 };
 
-template <typename TCfg>
+template <typename TCfgList>
 class NodeList : public detail::INode{
 public:
-    NodeList(std::string name, std::vector<TCfg>& nodeList, NodeListType type = NodeListType::Normal)
+    NodeList(std::string name, TCfgList& nodeList, NodeListType type = NodeListType::Normal)
         : name_{std::move(name)}
         , nodeList_{nodeList}
         , type_{type}
-    {}
+    {
+        static_assert(is_sequence_container_v<maybe_opt_t<TCfgList>>,
+                      "Node list field must be a sequence container or a sequence container placed in std::optional");
+    }
 
     void markValueIsSet()
     {
@@ -32,19 +36,21 @@ public:
     {
         hasValue_ = true;
         position_ = nodeList.position();
-        nodeList_.clear();
         if (!nodeList.isList())
             throw ConfigError{"Node list '" + name_ + "': config node must be a list.", nodeList.position()};
+        if constexpr(is_optional<TCfgList>::value)
+            nodeList_.emplace();
 
+        maybeOptValue(nodeList_).clear();
         for (auto i = 0; i < nodeList.asList().count(); ++i){
             const auto& treeNode = nodeList.asList().node(i);
             try {
-                auto cfg = TCfg{};
+                auto cfg = typename maybe_opt_t<TCfgList>::value_type{};
                 auto& node = static_cast<IConfig&>(cfg);
                 if (type_ == NodeListType::Copy && i > 0)
                     node.load(nodeList.asList().node(0));
                 node.load(treeNode);
-                nodeList_.emplace_back(std::move(cfg));
+                maybeOptValue(nodeList_).emplace_back(std::move(cfg));
             } catch (const LoadingError& e) {
                 throw ConfigError{"Node list '" + name_ + "': " + e.what(), treeNode.position()};
             }
@@ -53,6 +59,8 @@ public:
 
     bool hasValue() const override
     {
+        if constexpr (is_optional<TCfgList>::value)
+            return true;
         return hasValue_;
     }
 
@@ -68,7 +76,7 @@ public:
 
 private:
     std::string name_;
-    std::vector<TCfg>& nodeList_;
+    TCfgList& nodeList_;
     bool hasValue_ = false;
     StreamPosition position_;
     NodeListType type_;

--- a/include/figcone/detail/nodelistcreator.h
+++ b/include/figcone/detail/nodelistcreator.h
@@ -19,7 +19,7 @@ public:
         , nodeListValue_(nodeList)
     {
         static_assert(is_sequence_container_v<maybe_opt_t<TCfgList>>,
-              "Node list field must be a sequence container or a sequence container placed in std::optional");
+                      "Node list field must be a sequence container or a sequence container placed in std::optional");
         static_assert(std::is_base_of_v<IConfig, typename maybe_opt_t<TCfgList>::value_type>,
                       "TNode must be a subclass of figcone::INode.");
     }

--- a/include/figcone/detail/nodelistcreator.h
+++ b/include/figcone/detail/nodelistcreator.h
@@ -6,61 +6,66 @@
 
 namespace figcone::detail{
 
-template<typename TCfg>
+template<typename TCfgList>
 class NodeListCreator{
 public:
     NodeListCreator(IConfig& cfg,
                     std::string nodeListName,
-                    std::vector<TCfg>& nodeList,
+                    TCfgList& nodeList,
                     NodeListType type = NodeListType::Normal)
         : cfg_{cfg}
         , nodeListName_{(Expects(!nodeListName.empty()), std::move(nodeListName))}
-        , nodeList_{std::make_unique<NodeList<TCfg>>(nodeListName_, nodeList, type)}
+        , nodeList_{std::make_unique<NodeList<TCfgList>>(nodeListName_, nodeList, type)}
         , nodeListValue_(nodeList)
     {
-        static_assert(std::is_base_of_v<IConfig, TCfg>, "TNode must be a subclass of figcone::INode.");
+        static_assert(is_sequence_container_v<maybe_opt_t<TCfgList>>,
+              "Node list field must be a sequence container or a sequence container placed in std::optional");
+        static_assert(std::is_base_of_v<IConfig, typename maybe_opt_t<TCfgList>::value_type>,
+                      "TNode must be a subclass of figcone::INode.");
     }
 
-    NodeListCreator<TCfg>& operator()()
+    NodeListCreator<TCfgList>& operator()()
     {
         nodeList_->markValueIsSet();
         return *this;
     }
 
-    operator std::vector<TCfg>()
+    operator TCfgList()
     {
         cfg_.addNode(nodeListName_, std::move(nodeList_));
         return {};
     }
 
-    NodeListCreator<TCfg>& ensure(std::function<void(const std::vector<TCfg>&)> validatingFunc)
+    NodeListCreator<TCfgList>& ensure(std::function<void(const TCfgList&)> validatingFunc)
     {
         cfg_.addValidator(
-                std::make_unique<Validator<std::vector<TCfg>>>(*nodeList_, nodeListValue_, std::move(validatingFunc)));
+                std::make_unique<Validator<TCfgList>>(*nodeList_, nodeListValue_, std::move(validatingFunc)));
         return *this;
     }
 
     template <typename TValidator, typename... TArgs>
-    NodeListCreator<TCfg>& ensure(TArgs&&... args)
+    NodeListCreator<TCfgList>& ensure(TArgs&&... args)
     {
-        cfg_.addValidator(std::make_unique<Validator<std::vector<TCfg>>>(*nodeList_, nodeListValue_, TValidator{std::forward<TArgs>(args)...}));
+        cfg_.addValidator(std::make_unique<Validator<TCfgList>>(*nodeList_, nodeListValue_, TValidator{std::forward<TArgs>(args)...}));
         return *this;
     }
 
 private:
     IConfig& cfg_;
     std::string nodeListName_;
-    std::unique_ptr<NodeList<TCfg>> nodeList_;
-    std::vector<TCfg>& nodeListValue_;
+    std::unique_ptr<NodeList<TCfgList>> nodeList_;
+    TCfgList& nodeListValue_;
 };
 
-template<typename TCfg, typename TParentCfg>
-NodeListCreator <TCfg> makeNodeListCreator(TParentCfg& parentCfg,
-                                           std::string nodeListName,
-                                           const std::function<std::vector<TCfg>&()>& nodeListGetter,
-                                           NodeListType type = NodeListType::Normal)
+template<typename TCfgList, typename TParentCfg>
+NodeListCreator <TCfgList> makeNodeListCreator(TParentCfg& parentCfg,
+                                               std::string nodeListName,
+                                               const std::function<TCfgList&()>& nodeListGetter,
+                                               NodeListType type = NodeListType::Normal)
 {
-    static_assert(TCfg::format() == TParentCfg::format(),
+    static_assert(is_sequence_container_v<maybe_opt_t<TCfgList>>,
+              "Node list field must be a sequence container or a sequence container placed in std::optional");
+    static_assert(maybe_opt_t<TCfgList>::value_type::format() == TParentCfg::format(),
                   "Node's config type must have the same name format as its parent.");
     return {parentCfg, std::move(nodeListName), nodeListGetter(), type};
 }

--- a/include/figcone/detail/paramlistcreator.h
+++ b/include/figcone/detail/paramlistcreator.h
@@ -4,45 +4,49 @@
 #include "inode.h"
 #include "validator.h"
 #include "gsl_assert.h"
+#include "utils.h"
 #include <vector>
 
 namespace figcone::detail{
 
-template<typename T>
+template<typename TParamList>
 class ParamListCreator{
 public:
     ParamListCreator(IConfig& cfg,
                      std::string paramListName,
-                     std::vector<T>& paramListValue)
+                     TParamList& paramListValue)
         : cfg_{cfg}
         , paramListName_{(Expects(!paramListName.empty()), std::move(paramListName))}
         , paramListValue_{paramListValue}
-        , paramList_{std::make_unique<ParamList<T>>(paramListName_, paramListValue)}
+        , paramList_{std::make_unique<ParamList<TParamList>>(paramListName_, paramListValue)}
     {
+        static_assert(is_sequence_container_v<maybe_opt_t<TParamList>>,
+                      "Param list field must be a sequence container or a sequence container placed in std::optional");
     }
 
-    ParamListCreator<T>& operator()(std::vector<T> defaultValue = {})
+    ParamListCreator<TParamList>& operator()(TParamList defaultValue = {})
     {
         defaultValue_ = std::move(defaultValue);
         paramList_->markValueIsSet();
         return *this;
     }
 
-    ParamListCreator<T>& ensure(std::function<void(const std::vector<T>&)> validatingFunc)
+    ParamListCreator<TParamList>& ensure(std::function<void(const TParamList&)> validatingFunc)
     {
         cfg_.addValidator(
-                std::make_unique<Validator<std::vector<T>>>(*paramList_, paramListValue_, std::move(validatingFunc)));
+                std::make_unique<Validator<TParamList>>(*paramList_, paramListValue_, std::move(validatingFunc)));
         return *this;
     }
 
     template <typename TValidator, typename... TArgs>
-    ParamListCreator<T>& ensure(TArgs&&... args)
+    ParamListCreator<TParamList>& ensure(TArgs&&... args)
     {
-        cfg_.addValidator(std::make_unique<Validator<std::vector<T>>>(*paramList_, paramListValue_, TValidator{std::forward<TArgs>(args)...}));
+        cfg_.addValidator(std::make_unique<Validator<TParamList>>(*paramList_, paramListValue_,
+                                                                  TValidator{std::forward<TArgs>(args)...}));
         return *this;
     }
 
-    operator std::vector<T>()
+    operator TParamList()
     {
         cfg_.addParam(paramListName_, std::move(paramList_));
         return defaultValue_;
@@ -51,16 +55,18 @@ public:
 private:
     IConfig& cfg_;
     std::string paramListName_;
-    std::vector<T>& paramListValue_;
-    std::unique_ptr<ParamList<T>> paramList_;
-    std::vector<T> defaultValue_;
+    TParamList& paramListValue_;
+    std::unique_ptr<ParamList<TParamList>> paramList_;
+    TParamList defaultValue_;
 };
 
-template<typename T>
-ParamListCreator<T> makeParamListCreator(IConfig& cfg,
-                                         std::string paramListName,
-                                         const std::function<std::vector<T>&()>& paramGetter)
+template<typename TParamList>
+ParamListCreator<TParamList> makeParamListCreator(IConfig& cfg,
+                                                  std::string paramListName,
+                                                  const std::function<TParamList&()>& paramGetter)
 {
+    static_assert(is_sequence_container_v<maybe_opt_t<TParamList>>,
+                  "Param list field must be a sequence container or a sequence container placed in std::optional");
     return {cfg, std::move(paramListName), paramGetter()};
 }
 

--- a/include/figcone/detail/utils.h
+++ b/include/figcone/detail/utils.h
@@ -26,6 +26,22 @@ struct is_sequence_container<T,
 template <typename T>
 inline constexpr auto is_sequence_container_v = is_sequence_container<T>::value;
 
+template <typename, typename = void>
+struct is_associative_container : std::false_type{};
+
+template <typename T>
+struct is_associative_container<T,
+        std::void_t<typename T::key_type,
+                    typename T::mapped_type,
+                    decltype(std::declval<T>().begin()),
+                    decltype(std::declval<T>().end()),
+                    decltype(std::declval<T>().emplace(std::declval<typename T::key_type>(),
+                                                       std::declval<typename T::mapped_type>()))>
+> : std::true_type{};
+
+template <typename T>
+inline constexpr auto is_associative_container_v = is_associative_container<T>::value;
+
 template<typename T>
 auto& maybeOptValue(T& obj)
 {

--- a/include/figcone/detail/utils.h
+++ b/include/figcone/detail/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <optional>
+#include <vector>
 #include <type_traits>
 
 namespace figcone::detail {
@@ -9,5 +10,42 @@ struct is_optional : std::false_type {};
 
 template<typename T>
 struct is_optional<std::optional<T> > : std::true_type {};
+
+
+template <typename, typename = void>
+struct is_sequence_container : std::false_type{};
+
+template <typename T>
+struct is_sequence_container<T,
+    std::void_t< typename T::value_type,
+                 decltype(std::declval<T>().begin()),
+                 decltype(std::declval<T>().end()),
+                 decltype(std::declval<T>().emplace_back(std::declval<typename T::value_type>()))>
+> : std::true_type{};
+
+template <typename T>
+inline constexpr auto is_sequence_container_v = is_sequence_container<T>::value;
+
+template<typename T>
+auto& maybeOptValue(T& obj)
+{
+    if constexpr(is_optional<T>::value)
+        return *obj;
+    else
+        return obj;
+}
+
+template<typename T, typename = void>
+struct maybe_opt{
+    using type = T;
+};
+template<typename T>
+struct maybe_opt<std::optional<T>>{
+    using type = T;
+};
+
+template<typename T>
+using maybe_opt_t = typename maybe_opt<T>::type;
+
 
 }

--- a/tests/test_copynodelist.cpp
+++ b/tests/test_copynodelist.cpp
@@ -17,11 +17,11 @@ struct Node : public figcone::Config<figcone::NameFormat::CamelCase>{
 };
 
 struct Cfg: public figcone::Config<figcone::NameFormat::CamelCase>{
-    FIGCONE_COPY_NODELIST(testNodes, Node);
+    FIGCONE_COPY_NODELIST(testNodes, std::vector<Node>);
 };
 
 struct Cfg2: public figcone::Config<figcone::NameFormat::CamelCase>{
-    FIGCONE_COPY_NODELIST(testNodes, Node);
+    FIGCONE_COPY_NODELIST(testNodes, std::vector<Node>);
     FIGCONE_PARAM(testDouble, double);
 };
 
@@ -37,7 +37,7 @@ struct CfgWithoutMacro: public figcone::Config<figcone::NameFormat::CamelCase>{
 
 struct NestedCfgList: public figcone::Config<figcone::NameFormat::CamelCase>{
     FIGCONE_PARAM(testStr, std::string);
-    FIGCONE_COPY_NODELIST(testList, Cfg2);
+    FIGCONE_COPY_NODELIST(testList, std::vector<Cfg2>);
 };
 
 class TreeProvider : public figcone::IParser{

--- a/tests/test_dict.cpp
+++ b/tests/test_dict.cpp
@@ -53,7 +53,7 @@ struct ValidatedWithFunctorCfg : public figcone::Config<> {
 #ifdef NAMEOF_AVAILABLE
 struct DictCfgWithoutMacro : public figcone::Config<>{
     std::map<std::string, std::string> test = dict<&DictCfgWithoutMacro::test>();
-    std::unordered_map<std::string, std::string> optTest = dict<&DictCfgWithoutMacro::optTest>();
+    std::unordered_map<std::string, std::string> optTest = dict<&DictCfgWithoutMacro::optTest>()();
     std::optional<std::map<std::string, std::string>> optTest2 = dict<&DictCfgWithoutMacro::optTest2>();
 };
 #else

--- a/tests/test_paramlist.cpp
+++ b/tests/test_paramlist.cpp
@@ -3,21 +3,27 @@
 #include <figcone/config.h>
 #include <figcone/errors.h>
 #include <figcone_tree/tree.h>
+#include <optional>
 
 #if __has_include(<nameof.hpp>)
 #define NAMEOF_AVAILABLE
 #endif
 
-
 namespace test_paramlist {
 
 struct CfgInt : public figcone::Config<figcone::NameFormat::CamelCase>
 {
-    FIGCONE_PARAMLIST(testIntList, int);
+    FIGCONE_PARAMLIST(testIntList, std::deque<int>);
+};
+
+struct CfgOptInt : public figcone::Config<figcone::NameFormat::CamelCase>
+{
+    FIGCONE_PARAMLIST(testIntList, std::optional<std::deque<int>>);
 };
 
 struct NotEmpty{
-    void operator()(const std::vector<std::string>& value)
+    template<typename T>
+    void operator()(const T& value)
     {
         if (value.empty())
             throw figcone::ValidationError{"a list can't be empty"};
@@ -25,7 +31,8 @@ struct NotEmpty{
 };
 
 struct HasNoEmptyElements{
-    void operator()(const std::vector<std::string>& value)
+    template<typename T>
+    void operator()(const T& value)
     {
         if (std::find_if(value.begin(), value.end(), [](const auto& str){
             return str.empty();
@@ -36,7 +43,7 @@ struct HasNoEmptyElements{
 
 struct ValidatedCfg : public figcone::Config<figcone::NameFormat::CamelCase>
 {
-    FIGCONE_PARAMLIST(testStrList, std::string)
+    FIGCONE_PARAMLIST(testStrList, std::vector<std::string>)
         .ensure([](const std::vector<std::string>& value)
         {
             if (value.empty()) throw figcone::ValidationError{"a list can't be empty"};
@@ -45,7 +52,7 @@ struct ValidatedCfg : public figcone::Config<figcone::NameFormat::CamelCase>
 
 struct ValidatedWithFunctorCfg : public figcone::Config<figcone::NameFormat::CamelCase>
 {
-    FIGCONE_PARAMLIST(testStrList, std::string)
+    FIGCONE_PARAMLIST(testStrList, std::vector<std::string>)
     .ensure<NotEmpty>()
     .ensure<HasNoEmptyElements>();
 };
@@ -64,8 +71,8 @@ struct CfgIntWithoutMacro : public figcone::Config<figcone::NameFormat::CamelCas
 
 struct CfgStr : public figcone::Config<figcone::NameFormat::CamelCase>
 {
-    FIGCONE_PARAMLIST(testStrList, std::string);
-    FIGCONE_PARAMLIST(testIntList, int)({1, 2, 3});
+    FIGCONE_PARAMLIST(testStrList, std::vector<std::string>);
+    FIGCONE_PARAMLIST(testIntList, std::vector<int>)({1, 2, 3});
 };
 
 class TreeProvider : public figcone::IParser{
@@ -98,6 +105,37 @@ TEST(TestParamList, Basic)
     EXPECT_EQ(cfg.testIntList.at(0), 1);
     EXPECT_EQ(cfg.testIntList.at(1), 2);
     EXPECT_EQ(cfg.testIntList.at(2), 3);
+}
+
+TEST(TestParamList, BasicOptional)
+{
+    auto cfg = CfgOptInt{};
+
+///testIntList = [1, 2, 3]
+///
+    auto tree = figcone::makeTreeRoot();
+    tree.asItem().addParamList("testIntList", std::vector<std::string>{"1", "2", "3"}, {1, 1});
+    auto parser = TreeProvider{std::move(tree)};
+
+    cfg.read("", parser);
+
+    ASSERT_TRUE(cfg.testIntList);
+    ASSERT_EQ(cfg.testIntList->size(), 3);
+    EXPECT_EQ(cfg.testIntList->at(0), 1);
+    EXPECT_EQ(cfg.testIntList->at(1), 2);
+    EXPECT_EQ(cfg.testIntList->at(2), 3);
+}
+
+TEST(TestParamList, BasicMissingOptional)
+{
+    auto cfg = CfgOptInt{};
+
+    auto tree = figcone::makeTreeRoot();
+    auto parser = TreeProvider{std::move(tree)};
+
+    cfg.read("", parser);
+
+    ASSERT_FALSE(cfg.testIntList);
 }
 
 TEST(TestParamList, BasicWithoutMacro)

--- a/tests/test_paramlist.cpp
+++ b/tests/test_paramlist.cpp
@@ -4,6 +4,9 @@
 #include <figcone/errors.h>
 #include <figcone_tree/tree.h>
 #include <optional>
+#include <vector>
+#include <deque>
+#include <list>
 
 #if __has_include(<nameof.hpp>)
 #define NAMEOF_AVAILABLE
@@ -13,7 +16,7 @@ namespace test_paramlist {
 
 struct CfgInt : public figcone::Config<figcone::NameFormat::CamelCase>
 {
-    FIGCONE_PARAMLIST(testIntList, std::deque<int>);
+    FIGCONE_PARAMLIST(testIntList, std::list<int>);
 };
 
 struct CfgOptInt : public figcone::Config<figcone::NameFormat::CamelCase>
@@ -60,12 +63,12 @@ struct ValidatedWithFunctorCfg : public figcone::Config<figcone::NameFormat::Cam
 #ifdef NAMEOF_AVAILABLE
 struct CfgIntWithoutMacro : public figcone::Config<figcone::NameFormat::CamelCase>
 {
-    std::vector<int> testIntList = paramList<&CfgIntWithoutMacro::testIntList>();
+    std::list<int> testIntList = paramList<&CfgIntWithoutMacro::testIntList>();
 };
 #else
 struct CfgIntWithoutMacro : public figcone::Config<figcone::NameFormat::CamelCase>
 {
-    std::vector<int> testIntList = paramList<&CfgIntWithoutMacro::testIntList>("testIntList");
+    std::list<int> testIntList = paramList<&CfgIntWithoutMacro::testIntList>("testIntList");
 };
 #endif
 
@@ -102,9 +105,9 @@ TEST(TestParamList, Basic)
     cfg.read("", parser);
 
     ASSERT_EQ(cfg.testIntList.size(), 3);
-    EXPECT_EQ(cfg.testIntList.at(0), 1);
-    EXPECT_EQ(cfg.testIntList.at(1), 2);
-    EXPECT_EQ(cfg.testIntList.at(2), 3);
+    EXPECT_EQ(*cfg.testIntList.begin(), 1);
+    EXPECT_EQ(*std::next(cfg.testIntList.begin(), 1), 2);
+    EXPECT_EQ(*std::next(cfg.testIntList.begin(), 2), 3);
 }
 
 TEST(TestParamList, BasicOptional)
@@ -151,9 +154,9 @@ TEST(TestParamList, BasicWithoutMacro)
     cfg.read("", parser);
 
     ASSERT_EQ(cfg.testIntList.size(), 3);
-    EXPECT_EQ(cfg.testIntList.at(0), 1);
-    EXPECT_EQ(cfg.testIntList.at(1), 2);
-    EXPECT_EQ(cfg.testIntList.at(2), 3);
+    EXPECT_EQ(*cfg.testIntList.begin(), 1);
+    EXPECT_EQ(*std::next(cfg.testIntList.begin(), 1), 2);
+    EXPECT_EQ(*std::next(cfg.testIntList.begin(), 2), 3);
 }
 
 TEST(TestParamList, ValidationSuccess)


### PR DESCRIPTION
Now all config field registration methods support setiing default values with operator() and all config fields can use types placed in std::optional.