### PR TITLE
Unregistered data handler (fixes #16)

### DIFF
--- a/include/figcone/unknown_data.h
+++ b/include/figcone/unknown_data.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <functional>
+#include "figcone_tree/streamposition.h"
+
+namespace figcone {
+
+typedef std::function<void(std::string node,
+                           std::string param,
+                           StreamPosition position)> UnknownDataHandler;
+
+static inline UnknownDataHandler defaultUnknownDataHandler()
+{
+    return [](std::string nodeName, std::string paramName, StreamPosition position) {
+        if(!nodeName.empty())
+            throw ConfigError{"Unknown node '" + nodeName + "'", position};
+        throw ConfigError{"Unknown param '" + paramName + "'", position};
+    };
+}    
+                            
+} //namespace figcone


### PR DESCRIPTION
This is a first attempt at #16 using a std::function and a global (fixed) default.

Includes two new test cases.

My feeling is that it might be too simple given the rest of the design but it is user facing so it might be good keeping it simpler.

Potential issues:

* There is a new header file, it might be possible to fold everything into the existing `configreader.h`.
* The name of the new header `unknown_data.h` might not gel well with the other header names.
* The typedef for the std::function is a little long (`UnknownDataHandler`).
* The handler function receives a `figcone::StreamPosition` (defined in `figcone_tree/streamposition.h`). That might be exposing too much implementation details to the user.
* Using a class rather than a simpler std::function might be able to distinguish between unknown nodes and unknown parameters as different calls.
* I couldn't find a way to keep a global default that could be modified in a header-only solution. The global default is hardwired and cannot be changed.
* Nested readers most probably won't inherit the data handler

I'll be happy to evolve the changes and address some of these issues based on your review.

Once the changes are good, I can include also changes to the README and maybe an example if you think that'll be good.
