### PR TITLE
Fix: Resolve circular dependency and dependent template names

### DIFF
--- a/include/figcone/detail/node.h
+++ b/include/figcone/detail/node.h
@@ -45,11 +45,11 @@ private:
             cfg_.emplace();
 
         if constexpr (!std::is_base_of_v<figcone::Config, eel::remove_optional_t<TCfg>>) {
-            ConfigReaderAccess{cfgReader_}.loadStructure<eel::remove_optional_t<TCfg>>(maybeOptValue(cfg_));
+            ConfigReaderAccess{cfgReader_}.template loadStructure<eel::remove_optional_t<TCfg>>(maybeOptValue(cfg_));
         }
 
         if (cfgReader_)
-            ConfigReaderAccess{cfgReader_}.load<TCfg>(node);
+            ConfigReaderAccess{cfgReader_}.template load<TCfg>(node);
     }
 
     bool hasValue() const override

--- a/include/figcone/detail/nodelist.h
+++ b/include/figcone/detail/nodelist.h
@@ -12,6 +12,10 @@
 #include <type_traits>
 #include <vector>
 
+namespace figcone {
+class Config;
+}
+
 namespace figcone::detail {
 
 enum class NodeListType {
@@ -63,19 +67,19 @@ public:
                     auto cfg = Cfg{cfgReader_};
                     if (cfgReader_) {
                         if (type_ == NodeListType::Copy && i > 0)
-                            ConfigReaderAccess{cfgReader_}.load<Cfg>(nodeList.asList().at(0));
-                        ConfigReaderAccess{cfgReader_}.load<Cfg>(treeNode);
+                            ConfigReaderAccess{cfgReader_}.template load<Cfg>(nodeList.asList().at(0));
+                        ConfigReaderAccess{cfgReader_}.template load<Cfg>(treeNode);
                     }
                     maybeOptValue(nodeList_).emplace_back(std::move(cfg));
                 }
                 else {
                     auto cfg = Cfg{};
                     if (cfgReader_) {
-                        ConfigReaderAccess{cfgReader_}.loadStructure<Cfg>(cfg);
+                        ConfigReaderAccess{cfgReader_}.template loadStructure<Cfg>(cfg);
 
                         if (type_ == NodeListType::Copy && i > 0)
-                            ConfigReaderAccess{cfgReader_}.load<Cfg>(nodeList.asList().at(0));
-                        ConfigReaderAccess{cfgReader_}.load<Cfg>(treeNode);
+                            ConfigReaderAccess{cfgReader_}.template load<Cfg>(nodeList.asList().at(0));
+                        ConfigReaderAccess{cfgReader_}.template load<Cfg>(treeNode);
                     }
                     maybeOptValue(nodeList_).emplace_back(std::move(cfg));
                 }


### PR DESCRIPTION

**1. Circular Header Dependency**

A circular dependency between `nodelist.h` and `config.h` has been resolved. The file `nodelist.h` was including `config.h`, which in turn was indirectly including `nodelist.h` back, creating a recursive inclusion loop.

This was fixed by replacing the `#include <figcone/config.h>` directive in `nodelist.h` with a forward declaration (`class Config;`), which breaks the dependency cycle.

**2. Dependent Template Name Lookup**

A compilation error related to dependent name lookup has been fixed. The compiler could not determine if `load` and `loadStructure` were template functions because they were being called with a type `Cfg` that depends on a template parameter.

The `template` keyword has been added before these calls to disambiguate them, as required by the C++ standard.


Marcos